### PR TITLE
Use consistent API port

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ Once installed, start the server with:
 npm start
 ```
 
-The frontend expects this API to be available at `http://localhost:5000`. If the server isn't running or its dependencies are missing you may see `failed to fetch` errors in the browser.
+The frontend expects this API to be available at `http://localhost:3000`. If the server isn't running or its dependencies are missing you may see `failed to fetch` errors in the browser.

--- a/server/index.js
+++ b/server/index.js
@@ -20,7 +20,7 @@ mongoose.connect(mongoURI, { useNewUrlParser: true, useUnifiedTopology: true })
 
 // --- API Routes ---
 app.use('/api/inventory', require('./routes/inventory'));
-app.use('/api/logs', require('./routes/logs'));
+app.use('/api/logs', require('./routes/Logs'));
 
 // --- Start Server ---
 app.listen(port, () => {

--- a/src/components/modals/UseStockModal.jsx
+++ b/src/components/modals/UseStockModal.jsx
@@ -8,7 +8,7 @@ import { Button } from '../common/Button';
 import { ErrorMessage } from '../common/ErrorMessage';
 import { X } from 'lucide-react';
 
-const API_BASE_URL = 'http://localhost:5000/api';
+const API_BASE_URL = 'http://localhost:3000/api';
 
 export const UseStockModal = ({ onClose, onStockUsed }) => {
     const { jobs, setJobField, setItemField, addJob, removeJob, addMaterial, removeMaterial } = useOrderForm();

--- a/src/hooks/useApiData.js
+++ b/src/hooks/useApiData.js
@@ -1,7 +1,7 @@
 // src/hooks/useApiData.js
 import { useState, useEffect, useCallback } from 'react';
 
-const API_BASE_URL = 'http://localhost:3000 / api';
+const API_BASE_URL = 'http://localhost:3000/api';
 
 export function useApiData() {
     const [inventory, setInventory] = useState([]);


### PR DESCRIPTION
## Summary
- match API server port to frontend (3000)
- update all API_BASE_URL constants accordingly

## Testing
- `npm run build`
- `cd server && npm install`
- `timeout 5 npm start`


------
https://chatgpt.com/codex/tasks/task_e_688285766908833183ca580811eb9495