### PR TITLE
Fix base URL parsing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,8 +29,10 @@ import { AddOrderModal } from './components/modals/AddOrderModal';
 import { UseStockModal } from './components/modals/UseStockModal';
 import { EditOutgoingLogModal } from './components/modals/EditOutgoingLogModal';
 
-// Define the base URL for your custom API server
-const API_BASE_URL = 'http://localhost:3000/api';
+// Define the base URL for your custom API server. Trim any whitespace in case
+// environment variables contain stray spaces which would break fetch.
+const API_BASE_URL =
+    (process.env.REACT_APP_API_BASE_URL || 'http://localhost:3000/api').trim();
 
 export default function App() {
     // State management using the new custom hook

--- a/src/components/modals/UseStockModal.jsx
+++ b/src/components/modals/UseStockModal.jsx
@@ -8,7 +8,10 @@ import { Button } from '../common/Button';
 import { ErrorMessage } from '../common/ErrorMessage';
 import { X } from 'lucide-react';
 
-const API_BASE_URL = 'http://localhost:3000/api';
+// Base URL used for API requests. Trim to ensure no stray whitespace causes
+// malformed URLs.
+const API_BASE_URL =
+    (process.env.REACT_APP_API_BASE_URL || 'http://localhost:3000/api').trim();
 
 export const UseStockModal = ({ onClose, onStockUsed }) => {
     const { jobs, setJobField, setItemField, addJob, removeJob, addMaterial, removeMaterial } = useOrderForm();

--- a/src/hooks/useApiData.js
+++ b/src/hooks/useApiData.js
@@ -1,7 +1,10 @@
 // src/hooks/useApiData.js
 import { useState, useEffect, useCallback } from 'react';
 
-const API_BASE_URL = 'http://localhost:3000/api';
+// Allow overriding the API base via environment variable and trim any
+// whitespace to avoid malformed URLs.
+const API_BASE_URL =
+    (process.env.REACT_APP_API_BASE_URL || 'http://localhost:3000/api').trim();
 
 export function useApiData() {
     const [inventory, setInventory] = useState([]);


### PR DESCRIPTION
## Summary
- sanitize API base URL constant across client

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68828b80bb0c8331849f160cad946b2d