### PR TITLE
Handle non-JSON responses

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,14 +23,17 @@ import { DashboardView } from './views/DashboardView';
 import { LogsView } from './views/LogsView';
 import { MaterialDetailView } from './views/MaterialDetailView';
 import { CostAnalyticsView } from './views/CostAnalyticsView';
+import { parseJsonSafe } from './utils/request';
 
 // Modals
 import { AddOrderModal } from './components/modals/AddOrderModal';
 import { UseStockModal } from './components/modals/UseStockModal';
 import { EditOutgoingLogModal } from './components/modals/EditOutgoingLogModal';
 
-// Define the base URL for your custom API server
-const API_BASE_URL = 'http://localhost:3000/api';
+// Define the base URL for your custom API server. Trim any whitespace in case
+// environment variables contain stray spaces which would break fetch.
+const API_BASE_URL =
+    (process.env.REACT_APP_API_BASE_URL || 'http://localhost:3000/api').trim();
 
 export default function App() {
     // State management using the new custom hook
@@ -65,8 +68,14 @@ export default function App() {
             });
 
             if (!response.ok) {
-                const res = await response.json();
-                throw new Error(res.message || 'Failed to save the order.');
+                let message = 'Failed to save the order.';
+                try {
+                    const resData = await parseJsonSafe(response);
+                    if (resData && resData.message) message = resData.message;
+                } catch (err) {
+                    if (typeof err === 'string') message = err;
+                }
+                throw new Error(message);
             }
             await refetchData(); // Refetch data to show changes
         } catch (err) {

--- a/src/hooks/useApiData.js
+++ b/src/hooks/useApiData.js
@@ -1,7 +1,11 @@
 // src/hooks/useApiData.js
 import { useState, useEffect, useCallback } from 'react';
+import { parseJsonSafe } from '../utils/request';
 
-const API_BASE_URL = 'http://localhost:3000/api';
+// Allow overriding the API base via environment variable and trim any
+// whitespace to avoid malformed URLs.
+const API_BASE_URL =
+    (process.env.REACT_APP_API_BASE_URL || 'http://localhost:3000/api').trim();
 
 export function useApiData() {
     const [inventory, setInventory] = useState([]);
@@ -23,8 +27,8 @@ export function useApiData() {
                 throw new Error('Failed to fetch data from the server.');
             }
 
-            const inventoryData = await inventoryRes.json();
-            const usageLogData = await usageLogRes.json();
+            const inventoryData = await parseJsonSafe(inventoryRes);
+            const usageLogData = await parseJsonSafe(usageLogRes);
 
             setInventory(inventoryData);
             setUsageLog(usageLogData);

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -1,0 +1,9 @@
+export async function parseJsonSafe(response) {
+    const text = await response.text();
+    try {
+        return JSON.parse(text);
+    } catch {
+        throw text || 'Invalid server response';
+    }
+}
+


### PR DESCRIPTION
## Summary
- add helper to safely parse API responses
- use parser in client fetches to avoid JSON errors

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68828b80bb0c8331849f160cad946b2d