### PR TITLE
Add thickness button to dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -131,6 +131,9 @@ export default function App() {
                             setScrollToMaterial(materialType);
                         }
                     }}
+                    onAddThickness={(matType) => {
+                        alert(`Add thickness for ${matType}`);
+                    }}
                 />;
             case 'logs':
                 return <LogsView

--- a/src/components/dashboard/MaterialCategoryCard.jsx
+++ b/src/components/dashboard/MaterialCategoryCard.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { MATERIAL_TYPES, MATERIALS, STANDARD_LENGTHS } from '../../constants/materials';
 
-export const MaterialCategoryCard = ({ category, inventorySummary, incomingSummary, isEditMode, onSave, onMaterialClick }) => {
+export const MaterialCategoryCard = ({ category, inventorySummary, incomingSummary, isEditMode, onSave, onMaterialClick, onAddThickness }) => {
     const materialsInCategory = MATERIAL_TYPES.filter(m => MATERIALS[m].category === category);
     const [editingCell, setEditingCell] = useState(null); // { matType, len }
     const [editValue, setEditValue] = useState('');
@@ -35,6 +35,7 @@ export const MaterialCategoryCard = ({ category, inventorySummary, incomingSumma
                             {STANDARD_LENGTHS.map(len => (
                                 <th key={len} className="p-2 font-semibold text-center text-slate-400 border-l border-slate-700">{len}"x48"</th>
                             ))}
+                            <th className="p-2 font-semibold text-center text-slate-400 border-l border-slate-700">Action</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -71,6 +72,11 @@ export const MaterialCategoryCard = ({ category, inventorySummary, incomingSumma
                                         </td>
                                     );
                                 })}
+                                <td className="p-2 text-center border-l border-slate-700">
+                                    <button onClick={() => onAddThickness && onAddThickness(matType)} className="text-blue-400 hover:text-blue-300 underline">
+                                        Add Thickness
+                                    </button>
+                                </td>
                             </tr>
                         ))}
                     </tbody>

--- a/src/views/DashboardView.jsx
+++ b/src/views/DashboardView.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { CATEGORIES } from '../constants/materials';
 import { MaterialCategoryCard } from '../components/dashboard/MaterialCategoryCard';
 
-export const DashboardView = ({ inventorySummary, incomingSummary, isEditMode, onSave, onMaterialClick }) => (
+export const DashboardView = ({ inventorySummary, incomingSummary, isEditMode, onSave, onMaterialClick, onAddThickness }) => (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         {CATEGORIES.map(category => (
             <MaterialCategoryCard
@@ -13,6 +13,7 @@ export const DashboardView = ({ inventorySummary, incomingSummary, isEditMode, o
                 isEditMode={isEditMode}
                 onSave={onSave}
                 onMaterialClick={onMaterialClick}
+                onAddThickness={onAddThickness}
             />
         ))}
     </div>


### PR DESCRIPTION
## Summary
- add `onAddThickness` callback support to dashboard
- display an **Add Thickness** button for each material row
- show a simple alert placeholder when clicking the button

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6883995902848331ba4fe57268cb8038